### PR TITLE
Fix options for `dc:` commands

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -50,35 +50,35 @@
     {
       "label": "dc:build",
       "type": "shell",
-      "command": "./run dc:build ${input:dcOpts}",
+      "command": "./run ${input:dcOpts} dc:build",
       "problemMatcher": [],
       "detail": "Build all docker services"
     },
     {
       "label": "dc:console",
       "type": "shell",
-      "command": "./run dc:console ${input:dcOpts}",
+      "command": "./run ${input:dcOpts} dc:console",
       "problemMatcher": [],
       "detail": "Build, start, up all services and console of 'app' docker service"
     },
     {
       "label": "dc:exec",
       "type": "shell",
-      "command": "./run dc:exec ${input:dcOpts} ",
+      "command": "./run ${input:dcOpts} dc:exec",
       "problemMatcher": [],
       "detail": "Execute a command in a 'app' docker service"
     },
     {
       "label": "dc:run",
       "type": "shell",
-      "command": "./run dc:run ${input:dcOpts} ${input:cmd}",
+      "command": "./run ${input:dcOpts} dc:run ${input:cmd}",
       "problemMatcher": [],
       "detail": "Run a command inside the 'app' docker service and remove stopped containers"
     },
     {
       "label": "dc:up",
       "type": "shell",
-      "command": "./run dc:up ${input:dcOpts}",
+      "command": "./run ${input:dcOpts} dc:up",
       "problemMatcher": [],
       "detail": "Starts all docker services"
     },
@@ -130,6 +130,7 @@
     {
       "id": "dcOpts",
       "type": "promptString",
+      "default": "--dev",
       "description": "Options? (e.g. --dev)"
     }
   ]

--- a/run
+++ b/run
@@ -19,9 +19,11 @@ $0 [command] [--dev] [sub-command]
 Example: $0 --dev dc:exec ./run test
 
 Options:
+  -h, --help                  Print this message
   --dev                       Use "dev" file when docker compose
 
 Main commands:
+  help                        Print this message
   format                      Format code of the whole project
   install-deps                Install all dependencies
   lint                        Lint the whole project
@@ -184,6 +186,10 @@ for opt in "${@}"; do
     --dev)
       dc_options=("${dev_dc_options[@]}")
       shift
+      ;;
+    -h | --help)
+      help
+      close
       ;;
   esac
 done

--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -45,3 +45,8 @@ function alert {
 function die {
   exit 1
 }
+
+# Wrapper for "exit" without error.
+function close {
+  exit 0
+}


### PR DESCRIPTION
- Improve `help` message
- Add `-h` and `--help` to print help message