### PR TITLE
chore(lint): Lint staged files and test project in parallel in `pre-commit`

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,14 +4,12 @@
 . "$(dirname "$0")/_/husky.sh"
 
 if [ -n "$RELEASE" ]; then
-  npx lint-staged
+  ./run lint-staged
 elif [ -n "$INSIDE_DOCKER" ]; then
-  npx lint-staged
-  ./run test
+  ./run pre-commit
 else
   ./run --dc-dev dc:build
   ./run --dc-dev dc:up
   ./run --dc-dev dc:exec ./run install-deps
-  ./run --dc-dev dc:exec npx lint-staged
-  ./run --dc-dev dc:exec ./run test
+  ./run --dc-dev dc:exec ./run pre-commit
 fi

--- a/.lintstagedrc.yml
+++ b/.lintstagedrc.yml
@@ -2,37 +2,28 @@
   - ./run spellcheck:lint
 
 "*.{css,less,sass,scss}":
-  - ./run css:format
-  - ./run prettier:format
   - ./run css:lint
   - ./run prettier:lint
 
 "*.{htm,html}":
-  - ./run prettier:format
   - ./run html:lint
   - ./run prettier:lint
 
 "*.js":
-  - ./run js:format
-  - ./run prettier:format
   - ./run js:lint
   - ./run prettier:lint
 
 "{run,.husky/*,*.sh}":
-  - ./run shell:format
   - ./run shell:lint
 
 "Dockerfile*":
-  - ./run dockerfile:format
   - ./run dockerfile:lint
 
 "*.{json,yaml,yml,htmlhintrc}":
-  - ./run prettier:format
   - ./run prettier:lint
 
 # CHANGELOG.md text is generated automatically.
 # Also, as the file grows, it will take longer to lint and format.
 "!(CHANGELOG).md":
-  - ./run prettier:format
   - ./run prettier:lint
   - ./run markdown:lint

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -37,12 +37,20 @@
       "detail": "Lint of the whole project"
     },
     {
+      "label": "lint-staged",
+      "type": "shell",
+      "command": "./run",
+      "args": ["lint"],
+      "problemMatcher": [],
+      "detail": "Lint staged files"
+    },
+    {
       "label": "pre-commit",
       "type": "shell",
       "command": "./run",
       "args": ["pre-commit"],
       "problemMatcher": [],
-      "detail": "Format, lint and test the whole project"
+      "detail": "Lint staged files and test the whole project"
     },
     {
       "label": "test",

--- a/run
+++ b/run
@@ -30,8 +30,8 @@ Example: $0 --dc-dev dc:exec ./run test
 
 Options:
   -h, --help                  Print this message
-  --dc-ci                        Use "ci" file when docker compose
-  --dc-dev                       Use "dev" file when docker compose
+  --dc-ci                     Use "ci" file when docker compose
+  --dc-dev                    Use "dev" file when docker compose
 
 Main commands:
   help                        Print this message
@@ -39,7 +39,8 @@ Main commands:
   format                      Format code of the whole project
   install-deps                Install all dependencies
   lint                        Lint the whole project
-  pre-commit                  Format, lint and test the whole project
+  lint-staged                 Lint staged files
+  pre-commit                  Lint staged and test the whole project
   test                        Test the whole project
 
 docker-compose commands:
@@ -122,8 +123,8 @@ function check {
   local all_checks
 
   all_checks=$(
-    print "${test_checks}" \
-      && print "${lint_checks}"
+    echo "${test_checks}" \
+      && echo "${lint_checks}"
   )
 
   # Run all checks concurrently
@@ -211,11 +212,32 @@ EOF
 
 function pre-commit {
   if is_inside_docker; then
-    format
-    check
+    local status=0
+    local pre_commit_checks
+
+    pre_commit_checks=$(
+      echo "${test_checks}" \
+        && echo lint-staged
+    )
+
+    # Run all checks concurrently
+    echo "${pre_commit_checks}" \
+      | parallel --keep-order --tagstring "[{1}]" "./run {1}" \
+      || status=${?}
+
+    if [[ ${status} -ne 0 ]]; then
+      alert "✖ Project checked: issue(s) found"
+      exit ${status}
+    fi
+
+    success "✔ Project checked"
   else
     dc:exec ./run pre-commit
   fi
+}
+
+function lint-staged {
+  npx lint-staged
 }
 
 function install-deps {


### PR DESCRIPTION
- Do not format while linting staged files
- Add `lint-staged` in `./run`
- Use `echo` instead of `print`
- Format `help` message