### PR TITLE
chore: Exclude more directories in `.*ignore` and `htmlhint`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,6 @@
+# Git
+.git/
+
 # Local history (VSCode extension)
 .history/
 

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,6 @@
+# Git
+.git/
+
 # Local history (VSCode extension)
 .history/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
+# Git
+.git/
+
 # Local history (VSCode extension)
 .history/
 

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,3 +1,6 @@
+# Git
+.git/
+
 # Local history (VSCode extension)
 .history/
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
 
   // Files:
   "files.associations": {
+    ".markdownlintignore": "ignore",
     "**/.husky/*": "shellscript",
     "run": "shellscript"
   },

--- a/scripts/run/html.sh
+++ b/scripts/run/html.sh
@@ -10,6 +10,7 @@ EOF
 
 function html:lint {
   local ignore_globs=(
+    **/.git/**
     **/.history/**
     **/node_modules/**
     **/npm_cache/**


### PR DESCRIPTION
- Set `.markdownlintignore` as `ignore` file type