### PR TITLE
build(docker): Move env variables as runtime env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ FROM ubuntu:focal-20220105 as base
 
 USER root
 
-ENV INSIDE_DOCKER=1
-ENV LANG=en_US.UTF-8
-
 RUN set -e \
   && export DEBIAN_FRONTEND=noninteractive \
   && echo "--- Install packages ---" \
@@ -17,15 +14,12 @@ RUN set -e \
     git=1:2.25.1-* \
     locales=2.31-* \
   && echo "--- Add locales ---" \
-  && sed -i "/${LANG}/s/^# //g" /etc/locale.gen \
-  && locale-gen ${LANG} \
+  && sed -i "/en_US.UTF-8/s/^# //g" /etc/locale.gen \
+  && locale-gen "en_US.UTF-8" \
   && echo "--- Clean ---" \
   && apt-get clean \
   && apt-get autoremove \
   && rm -rf /var/lib/apt/lists/*
-
-# Added here instead before `locale-gen` to avoid warnings
-ENV LC_ALL=${LANG}
 
 ENV USERNAME=app-user
 ARG GROUPNAME=${USERNAME}
@@ -95,8 +89,6 @@ RUN find /usr/local/bin/. -xtype l -exec rm {} \; 2>/dev/null
 
 USER ${USERNAME}
 
-ENV CI=true
-
 # —————————————————————————————————————————————— #
 #                       dev                      #
 # —————————————————————————————————————————————— #
@@ -121,8 +113,6 @@ RUN set -e \
   && apt-get clean \
   && apt-get autoremove \
   && rm -rf /var/lib/apt/lists/*
-
-ENV CI=false
 
 USER ${USERNAME}
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,3 +5,5 @@ services:
     image: aifrak/template-repo:ci
     build:
       target: ci
+    environment:
+      - CI=true

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,3 +5,5 @@ services:
     image: aifrak/template-repo:dev
     build:
       target: dev
+    environment:
+      - CI=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     user: ${USER_UID:-1000}:${USER_GID:-1000}
     command: sleep infinity
     environment:
-      - INSIDE_DOCKER=1
+      - INSIDE_DOCKER=true
       - LANG=en_US.UTF-8
     volumes:
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,9 @@ services:
         USER_GID: ${USER_GID:-1000}
     user: ${USER_UID:-1000}:${USER_GID:-1000}
     command: sleep infinity
+    environment:
+      - INSIDE_DOCKER=1
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US:en
     volumes:
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,5 @@ services:
     environment:
       - INSIDE_DOCKER=1
       - LANG=en_US.UTF-8
-      - LANGUAGE=en_US:en
     volumes:
       - .:/app

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,43 @@
+# Docker
+
+## `app` service
+
+### Environment variables
+
+<!-- markdownlint-disable no-inline-html-->
+
+<table>
+  <tr>
+    <th>Name</th>
+    <th>Description</th>
+    <th align="center">Custom</th>
+    <th>Possible value(s)</th>
+  </tr>
+  <tr>
+    <td><code>CI</code></td>
+    <td>Check if <code>./run</code> is executed on a CI environment.</td>
+    <td align="center">✅</td>
+    <td><code>true</code> or <code>false</code></td>
+  </tr>
+  <tr>
+    <td><code>INSIDE_DOCKER</code></td>
+    <td>Check if <code>./run</code> is executed in a docker container.</td>
+    <td align="center">✅</td>
+    <td><code>true</code> or <code>false</code></td>
+  </tr>
+  <tr>
+    <td><code>LANG</code></td>
+    <td>System variable for locales.</td>
+    <td align="center">❌</td>
+    <td>
+      <ul>
+        <li><code>en_US.UTF-8</code> (recommended)</li>
+        <li><code>C</code></li>
+        <li><code>C.UTF-8</code></li>
+        <li><code>POSIX</code></li>
+      </ul>
+    </td>
+  </tr>
+</table>
+
+<!-- markdownlint-enable  -->

--- a/run
+++ b/run
@@ -77,7 +77,7 @@ function is_inside_docker {
 }
 
 function is_ci {
-  if [[ "${CI:-false}" = true ]]; then
+  if [[ "${CI:-false}" == true ]]; then
     return 0
   else
     return 1

--- a/run
+++ b/run
@@ -68,9 +68,8 @@ EOF
 # —————————————————————————————————————————————— #
 
 # Check if the command is from the docker container or the host.
-# INSIDE_DOCKER=1 is set from the Dockerfile
 function is_inside_docker {
-  if [[ ${INSIDE_DOCKER:-0} -eq 1 ]]; then
+  if [[ ${INSIDE_DOCKER:-false} == true ]]; then
     return 0
   else
     return 1

--- a/spellcheck/dictionaries/workspace.txt
+++ b/spellcheck/dictionaries/workspace.txt
@@ -1,4 +1,3 @@
-# Ascending sort, case insensitive
 !hte
 calver
 conventionalcommits
@@ -9,6 +8,7 @@ dotfiles
 GROUPNAME
 infile
 noreply
+POSIX
 prealpha
 preminor
 prepatch


### PR DESCRIPTION
- Remove `LANGUAGE`
- Use boolean for `INSIDE_DOCKER`
- Add documentation about environments variables
- Use `==` instead of `=`