### PR TITLE
ci: Do not lint commit message when Dependabot is co-author

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,18 @@ jobs:
         run: |
           ./run --dc-ci dc:exec ./run check
 
-      - name: Lint latest git commit message
-        if: github.actor != 'dependabot[bot]'
+      - name: Set commit information
+        id: commit
         run: |
-          ./run --dc-ci dc:exec ./run git:commit:lint-latest
+          is_contributor_dependabot="false"
+
+          if ./run git:commit:is-contributor-dependabot; then is_contributor_dependabot="true"; fi
+
+          echo "::set-output name=is-contributor-dependabot::$is_contributor_dependabot"
+
+      - name: Lint git commit message
+        if: >-
+          github.actor != 'dependabot[bot]'
+          && steps.commit.outputs.is-contributor-dependabot == 'false'
+        run: |
+          ./run --dc-ci dc:exec ./run git:commit:lint

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -140,12 +140,12 @@
     /*                      Git                     */
     /* ———————————————————————————————————————————— */
     {
-      "label": "git:commit:lint-latest",
+      "label": "git:commit:lint",
       "type": "shell",
       "command": "./run",
-      "args": ["git:commit:lint-latest"],
+      "args": ["git:commit:lint"],
       "problemMatcher": [],
-      "detail": "Lint latest git commit message"
+      "detail": "Lint git commit message"
     },
     /* ———————————————————————————————————————————— */
     /*                   Markdown                   */

--- a/scripts/run/git.sh
+++ b/scripts/run/git.sh
@@ -4,21 +4,19 @@ function git:help {
   cat <<EOF
 
 Git commands:
-  git:commit:lint-latest      Lint latest git commit message
+  git:commit:lint                       Lint git commit message
+  git:commit:is-contributor-dependabot  Check if Dependabot is (co-)author of the commit
 EOF
 }
 
-function git:commit:lint-latest {
-  local commit_author
+# NOTE: Dependabot is not flexible to apply commitlint rules
+# see: https://github.com/dependabot/dependabot-core/issues/1666
+# see: https://github.com/dependabot/dependabot-core/issues/2056
+function git:commit:lint {
   local commit_message
 
-  commit_author=$(git log -1 --pretty=format:"%an")
-
-  if [[ "${commit_author}" == "dependabot[bot]" ]]; then
-    # NOTE: Dependabot is not flexible to apply commitlint rules
-    # see: https://github.com/dependabot/dependabot-core/issues/1666
-    # see: https://github.com/dependabot/dependabot-core/issues/2056
-    warning "SKIPPED ${FUNCNAME[0]}: Dependabot is author of latest commit"
+  if git:commit:is-contributor-dependabot; then
+    warning "SKIPPED './run ${FUNCNAME[0]}': Dependabot is (co-)author of latest commit"
 
     close
   fi
@@ -26,4 +24,26 @@ function git:commit:lint-latest {
   commit_message=$(git log -1 --pretty=format:"%s")
 
   echo "${commit_message}" | npx commitlint --color
+}
+
+function git:commit:is-contributor-dependabot {
+  is_author_dependabot || is_co_author_dependabot
+}
+
+function is_author_dependabot {
+  local commit_author
+  local dependabot_name="dependabot[bot]"
+
+  commit_author=$(git log -1 --pretty=format:"%an")
+
+  [[ "${commit_author}" == "${dependabot_name}" ]]
+}
+
+function is_co_author_dependabot {
+  local commit_co_author
+  local dependabot_name="dependabot[bot]"
+
+  commit_co_author=$(git log -1 --pretty=format:"%(trailers:key=Co-Authored-By,valueonly)")
+
+  [[ "${commit_co_author}" == *"${dependabot_name}"* ]]
 }

--- a/scripts/run/git.sh
+++ b/scripts/run/git.sh
@@ -21,7 +21,7 @@ function git:commit:lint {
     close
   fi
 
-  commit_message=$(git log -1 --pretty=format:"%s")
+  commit_message=$(git_log "%s")
 
   echo "${commit_message}" | npx commitlint --color
 }
@@ -30,11 +30,17 @@ function git:commit:is-contributor-dependabot {
   is_author_dependabot || is_co_author_dependabot
 }
 
+function git_log() {
+  local format="${1}"
+
+  git log -1 --pretty=format:"${format}"
+}
+
 function is_author_dependabot {
   local commit_author
   local dependabot_name="dependabot[bot]"
 
-  commit_author=$(git log -1 --pretty=format:"%an")
+  commit_author=$(git_log "%an")
 
   [[ "${commit_author}" == "${dependabot_name}" ]]
 }
@@ -43,7 +49,7 @@ function is_co_author_dependabot {
   local commit_co_author
   local dependabot_name="dependabot[bot]"
 
-  commit_co_author=$(git log -1 --pretty=format:"%(trailers:key=Co-Authored-By,valueonly)")
+  commit_co_author=$(git_log "%(trailers:key=Co-Authored-By,valueonly)")
 
   [[ "${commit_co_author}" == *"${dependabot_name}"* ]]
 }

--- a/spellcheck/dictionaries/bash-custom.txt
+++ b/spellcheck/dictionaries/bash-custom.txt
@@ -1,4 +1,3 @@
-# Ascending sort, case insensitive
 autoremove
 BUILDKIT
 buildx
@@ -10,5 +9,6 @@ noninteractive
 NOPASSWD
 tagstring
 TIMEFORMAT
+valueonly
 xargs
 xtype


### PR DESCRIPTION
- Rename commit lint function
- Move `git log -1` into `git_log()`
- Refactor