### PR TITLE
chore(deps-dev): Remove override of `glob-parent` for `htmlhint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,6 @@
     "commitizen": {
       "ansi-regex": "^6.0.1"
     },
-    "htmlhint": {
-      "glob-parent": "^6.0.2"
-    },
     "stylelint-config-idiomatic-order": {
       "stylelint-order": "^5.0.0"
     }


### PR DESCRIPTION
Related to #325