### PR TITLE
chore(deps-dev): Bump `minimist` to patch vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13175,7 +13175,7 @@
         "inquirer": "6.5.2",
         "is-utf8": "^0.2.1",
         "lodash": "^4.17.20",
-        "minimist": "1.2.5",
+        "minimist": "^1.2.6",
         "strip-bom": "4.0.0",
         "strip-json-comments": "3.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   },
   "overrides": {
     "commitizen": {
-      "ansi-regex": "^6.0.1"
+      "ansi-regex": "^6.0.1",
+      "minimist": "^1.2.6"
     },
     "stylelint-config-idiomatic-order": {
       "stylelint-order": "^5.0.0"

--- a/spellcheck/dictionaries/npm-packages.txt
+++ b/spellcheck/dictionaries/npm-packages.txt
@@ -1,4 +1,3 @@
-# Ascending sort, case insensitive
 airbnb
 browserslist
 commitizen
@@ -8,4 +7,5 @@ csstree
 htmlhint
 lintstaged
 markdownlint
+minimist
 stylelint


### PR DESCRIPTION
Patch CVE-2021-44906