### PR TITLE
chore(deps-dev): Remove `stylelint-use-nesting`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,8 +48,7 @@
         "stylelint-declaration-strict-value": "^1.8.0",
         "stylelint-high-performance-animation": "^1.6.0",
         "stylelint-no-unsupported-browser-features": "^5.0.3",
-        "stylelint-use-logical-spec": "^3.2.2",
-        "stylelint-use-nesting": "^3.0.0"
+        "stylelint-use-logical-spec": "^3.2.2"
       },
       "engines": {
         "node": "16",
@@ -10369,18 +10368,6 @@
         "stylelint": ">=13"
       }
     },
-    "node_modules/stylelint-use-nesting": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-use-nesting/-/stylelint-use-nesting-3.0.0.tgz",
-      "integrity": "sha512-BMzhXWbK5DdAYtZMQULn7VmWZXpy8Rwlx2PgeNYqKInQrKTJWM/TFKPScc+xvsGUc/6JPiUDeQQij9gFnOo8Kg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "stylelint": "10 - 13"
-      }
-    },
     "node_modules/stylelint/node_modules/balanced-match": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
@@ -19500,13 +19487,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/stylelint-use-logical-spec/-/stylelint-use-logical-spec-3.2.2.tgz",
       "integrity": "sha512-NNh1NWIEpponGnBrCQ+jdYgQRvzu0FUnDOO7ZeyPHlNKXHvRz8nvNFkU8zLUCLbpWjc92rN0G0gc0MDsjSRPMA==",
-      "dev": true,
-      "requires": {}
-    },
-    "stylelint-use-nesting": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-use-nesting/-/stylelint-use-nesting-3.0.0.tgz",
-      "integrity": "sha512-BMzhXWbK5DdAYtZMQULn7VmWZXpy8Rwlx2PgeNYqKInQrKTJWM/TFKPScc+xvsGUc/6JPiUDeQQij9gFnOo8Kg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "stylelint-declaration-strict-value": "^1.8.0",
     "stylelint-high-performance-animation": "^1.6.0",
     "stylelint-no-unsupported-browser-features": "^5.0.3",
-    "stylelint-use-logical-spec": "^3.2.2",
-    "stylelint-use-nesting": "^3.0.0"
+    "stylelint-use-logical-spec": "^3.2.2"
   },
   "overrides": {
     "commitizen": {


### PR DESCRIPTION
`stylelint-use-nesting` does not support node 16 with stylelint 14.

This package is dropped for now.