### PR TITLE
chore(scripts): Reorder script names

### DIFF
--- a/.devcontainer/setup-dev-env.sh
+++ b/.devcontainer/setup-dev-env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-./run install-deps
+./run install:deps
 
 cat <<EOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,13 +113,13 @@ jobs:
         run: |
           npm run prepare
 
-      - name: Set check flag for git:commit:lint
+      - name: Set check flag for lint:git:commit
         id: git-commit-lint
         run: |
           is_contributor_dependabot=false
           run_git_commit_lint=false
 
-          if ./run git:commit:is-contributor-dependabot; then is_contributor_dependabot=true; fi
+          if ./run is-contributor-dependabot:git:commit; then is_contributor_dependabot=true; fi
 
           if [[ github.actor != "dependabot[bot]" && $is_contributor_dependabot = false ]]; then
             run_git_commit_lint=true;
@@ -132,7 +132,7 @@ jobs:
           included_opts=
 
           if [[ ${{ steps.git-commit-lint.outputs.flag }} = true ]]; then
-            included_opts="--include git:commit:lint"
+            included_opts="--include lint:git:commit"
           fi
 
           ./run --dc-ci dc:exec ./run check $included_opts

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,12 +10,12 @@ if [ "${CI:-false}" = false ] && [ "$branch" = "main" ]; then
 fi
 
 if [ -n "$RELEASE" ]; then
-  ./run lint-staged
+  ./run lint:staged
 elif [ -n "$INSIDE_DOCKER" ]; then
   ./run pre-commit
 else
   ./run --dc-dev dc:build
   ./run --dc-dev dc:up
-  ./run --dc-dev dc:exec ./run install-deps
+  ./run --dc-dev dc:exec ./run install:deps
   ./run --dc-dev dc:exec ./run pre-commit
 fi

--- a/.lintstagedrc.yml
+++ b/.lintstagedrc.yml
@@ -1,29 +1,29 @@
 "*":
-  - ./run spellcheck:lint
+  - ./run lint:spellcheck
 
 "*.{css,less,sass,scss}":
-  - ./run css:lint
-  - ./run prettier:lint
+  - ./run lint:css
+  - ./run lint:prettier
 
 "*.{htm,html}":
-  - ./run html:lint
-  - ./run prettier:lint
+  - ./run lint:html
+  - ./run lint:prettier
 
 "*.js":
-  - ./run js:lint
-  - ./run prettier:lint
+  - ./run lint:js
+  - ./run lint:prettier
 
 "{run,.husky/*,*.sh}":
-  - ./run shell:lint
+  - ./run lint:shell
 
 "Dockerfile*":
-  - ./run dockerfile:lint
+  - ./run lint:dockerfile
 
 "*.{json,yaml,yml,htmlhintrc}":
-  - ./run prettier:lint
+  - ./run lint:prettier
 
 # CHANGELOG.md text is generated automatically.
 # Also, as the file grows, it will take longer to lint and format.
 "!(CHANGELOG).md":
-  - ./run prettier:lint
-  - ./run markdown:lint
+  - ./run lint:prettier
+  - ./run lint:markdown

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,10 +21,10 @@
       "detail": "Format code of the whole project"
     },
     {
-      "label": "install-deps",
+      "label": "install:deps",
       "type": "shell",
       "command": "./run",
-      "args": ["install-deps"],
+      "args": ["install:deps"],
       "problemMatcher": [],
       "detail": "Install all dependencies"
     },
@@ -37,10 +37,10 @@
       "detail": "Lint the whole project"
     },
     {
-      "label": "lint-staged",
+      "label": "lint:staged",
       "type": "shell",
       "command": "./run",
-      "args": ["lint-staged"],
+      "args": ["lint:staged"],
       "problemMatcher": [],
       "detail": "Lint staged files"
     },
@@ -102,18 +102,18 @@
     /*                     Shell                    */
     /* ———————————————————————————————————————————— */
     {
-      "label": "shell:format",
+      "label": "format:shell",
       "type": "shell",
       "command": "./run",
-      "args": ["shell:format"],
+      "args": ["format:shell"],
       "problemMatcher": [],
       "detail": "Format Shell scripts"
     },
     {
-      "label": "shell:lint",
+      "label": "lint:shell",
       "type": "shell",
       "command": "./run",
-      "args": ["shell:lint"],
+      "args": ["lint:shell"],
       "problemMatcher": [],
       "detail": "Lint Shell scripts"
     },
@@ -121,18 +121,18 @@
     /*                  Dockerfile                  */
     /* ———————————————————————————————————————————— */
     {
-      "label": "dockerfile:format",
+      "label": "format:dockerfile",
       "type": "shell",
       "command": "./run",
-      "args": ["dockerfile:format"],
+      "args": ["format:dockerfile"],
       "problemMatcher": [],
       "detail": "Format all Dockerfiles"
     },
     {
-      "label": "dockerfile:lint",
+      "label": "lint:dockerfile",
       "type": "shell",
       "command": "./run",
-      "args": ["dockerfile:lint"],
+      "args": ["lint:dockerfile"],
       "problemMatcher": [],
       "detail": "Lint all Dockerfiles"
     },
@@ -140,10 +140,10 @@
     /*                      Git                     */
     /* ———————————————————————————————————————————— */
     {
-      "label": "git:commit:lint",
+      "label": "lint:git:commit",
       "type": "shell",
       "command": "./run",
-      "args": ["git:commit:lint"],
+      "args": ["lint:git:commit"],
       "problemMatcher": [],
       "detail": "Lint git commit message"
     },
@@ -151,10 +151,10 @@
     /*                   Markdown                   */
     /* ———————————————————————————————————————————— */
     {
-      "label": "markdown:lint",
+      "label": "lint:markdown",
       "type": "shell",
       "command": "./run",
-      "args": ["markdown:lint"],
+      "args": ["lint:markdown"],
       "problemMatcher": [],
       "detail": "Lint markdown files"
     },
@@ -162,18 +162,18 @@
     /*                   Prettier                   */
     /* ———————————————————————————————————————————— */
     {
-      "label": "prettier:format",
+      "label": "format:prettier",
       "type": "shell",
       "command": "./run",
-      "args": ["prettier:format"],
+      "args": ["format:prettier"],
       "problemMatcher": [],
       "detail": "Format files handled by Prettier"
     },
     {
-      "label": "prettier:lint",
+      "label": "lint:prettier",
       "type": "shell",
       "command": "./run",
-      "args": ["prettier:lint"],
+      "args": ["lint:prettier"],
       "problemMatcher": [],
       "detail": "Lint files handled by Prettier"
     },
@@ -181,10 +181,10 @@
     /*                  Spellcheck                  */
     /* ———————————————————————————————————————————— */
     {
-      "label": "spellcheck:lint",
+      "label": "lint:spellcheck",
       "type": "shell",
       "command": "./run",
-      "args": ["spellcheck:lint"],
+      "args": ["lint:spellcheck"],
       "problemMatcher": [],
       "detail": "Run spellcheck"
     },
@@ -192,18 +192,18 @@
     /*             CSS, SCSS, SASS, LESS            */
     /* ———————————————————————————————————————————— */
     {
-      "label": "css:format",
+      "label": "format:css",
       "type": "shell",
       "command": "./run",
-      "args": ["css:format "],
+      "args": ["format:css "],
       "problemMatcher": [],
       "detail": "Format CSS, SCSS, SASS, LESS and any files containing CSS"
     },
     {
-      "label": "css:lint",
+      "label": "lint:css",
       "type": "shell",
       "command": "./run",
-      "args": ["css:lint "],
+      "args": ["lint:css "],
       "problemMatcher": [],
       "detail": "Lint CSS, SCSS, SASS, LESS and any files containing CSS"
     },
@@ -211,10 +211,10 @@
     /*                     HTML                     */
     /* ———————————————————————————————————————————— */
     {
-      "label": "html:lint",
+      "label": "lint:html",
       "type": "shell",
       "command": "./run",
-      "args": ["html:lint"],
+      "args": ["lint:html"],
       "problemMatcher": [],
       "detail": "Lint HTML files and templates"
     },
@@ -222,18 +222,18 @@
     /*                  Javascript                  */
     /* ———————————————————————————————————————————— */
     {
-      "label": "js:format",
+      "label": "format:js",
       "type": "shell",
       "command": "./run",
-      "args": ["js:format"],
+      "args": ["format:js"],
       "problemMatcher": [],
       "detail": "Format JS files and any files containing Javascript"
     },
     {
-      "label": "js:lint",
+      "label": "lint:js",
       "type": "shell",
       "command": "./run",
-      "args": ["js:lint"],
+      "args": ["lint:js"],
       "problemMatcher": [],
       "detail": "Lint JS files and any files containing Javascript"
     }

--- a/docs/code-convention.md
+++ b/docs/code-convention.md
@@ -20,13 +20,15 @@ To help you to choose the right `type` or `scope`, you can commit:
 
 ### Function names
 
+- Format as following: `[purpose]:[scope]` where it may have multiple sub-scopes
+  separated by `:`
 - Use `:` to separate scopes
 - Use `-` (kebab-case) for scope names or purposes
 - Use `_` (snake_case) for helper functions that should not directly be used by
   the CLI
 
 ```shellscript
-function dev:dotnet-core:global-install {
+function install:dev:dotnet-core:global {
   ...
 }
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -11,13 +11,13 @@
 1. Install the extension `ms-vscode-remote.remote-containers`.
 1. `Ctrl+Shift+P` and choose `Remote-Containers: Open Folder in Container...`
 1. Wait container to be built (it takes a while).
-1. Run `./run install-deps` to install all dependencies.
+1. Run `./run install:deps` to install all dependencies.
 1. Run `./run help` to see all commands for this project.
 
 ### Development without VSCode
 
 1. Run `./run --dc-dev dc:console` to enter the container.
-1. Run `./run install-deps` to install all dependencies.
+1. Run `./run install:deps` to install all dependencies.
 1. Run `./run help` to see all commands for this project.
 
 ## UID and GID inside the container

--- a/run
+++ b/run
@@ -35,9 +35,9 @@ Main commands:
   help                        Print this message
   check                       Test and lint the whole project
   format                      Format code of the whole project
-  install-deps                Install all dependencies
+  install:deps                Install all dependencies
   lint                        Lint the whole project
-  lint-staged                 Lint staged files
+  lint:staged                 Lint staged files
   pre-commit                  Lint staged files and test the whole project
   test                        Test the whole project
 
@@ -49,16 +49,16 @@ docker compose commands:
   dc:up                       Starts all docker services
 EOF
 
-  release:help
-  css:help
-  html:help
-  js:help
-  markdown:help
-  prettier:help
-  shell:help
-  dockerfile:help
-  spellcheck:help
-  git:help
+  help:release
+  help:css
+  help:html
+  help:js
+  help:markdown
+  help:prettier
+  help:shell
+  help:dockerfile
+  help:spellcheck
+  help:git
 }
 
 # —————————————————————————————————————————————— #
@@ -90,20 +90,20 @@ fi
 
 test_checks=$(
   cat <<EOF
-release:test
+test:release
 EOF
 )
 
 lint_checks=$(
   cat <<EOF
-css:lint
-dockerfile:lint
-html:lint
-js:lint
-markdown:lint
-prettier:lint
-shell:lint
-spellcheck:lint
+lint:css
+lint:dockerfile
+lint:html
+lint:js
+lint:markdown
+lint:prettier
+lint:shell
+lint:spellcheck
 EOF
 )
 
@@ -201,17 +201,17 @@ function format {
     # Run all formatters concurrently
     (
       cat <<EOF
-css
-dockerfile
-js
-shell
+format:css
+format:dockerfile
+format:js
+format:shell
 EOF
-    ) | parallel --keep-order --tagstring "[{1}]" "./run {1}:format" \
+    ) | parallel --keep-order --tagstring "[{1}]" "./run {1}" \
       || status=${?}
 
     # Prettier format should be done after CSS and JS format
     print "\e[30;47m———[prettier]———\e[0m"
-    ./run prettier:format || status=${?}
+    ./run format:prettier || status=${?}
 
     if [[ ${status} -ne 0 ]]; then
       alert "✖ Project could not be formatted completely: issue(s) found"
@@ -229,7 +229,7 @@ function pre-commit {
     local status=0
     local pre_commit_checks
 
-    pre_commit_checks=$(echo "${test_checks}" && echo lint-staged)
+    pre_commit_checks=$(echo "${test_checks}" && echo lint:staged)
 
     # Run all checks concurrently
     echo "${pre_commit_checks}" \
@@ -247,17 +247,17 @@ function pre-commit {
   fi
 }
 
-function lint-staged {
+function lint:staged {
   npx lint-staged
 }
 
-function install-deps {
+function install:deps {
   if is_inside_docker; then
     npm ci --quiet
 
     success "✔ Dependencies installed"
   else
-    dc:exec ./run install-deps
+    dc:exec ./run install:deps
   fi
 }
 

--- a/scripts/run/css.sh
+++ b/scripts/run/css.sh
@@ -2,16 +2,16 @@
 
 css_globs="**/*.{css,less,sass,scss}"
 
-function css:help {
+function help:css {
   cat <<EOF
 
 CSS commands:
-  css:format                  Format CSS, SCSS, SASS, LESS and any files containing CSS
-  css:lint                    Lint CSS, SCSS, SASS, LESS and any files containing CSS
+  format:css                  Format CSS, SCSS, SASS, LESS and any files containing CSS
+  lint:css                    Lint CSS, SCSS, SASS, LESS and any files containing CSS
 EOF
 }
 
-function css:lint {
+function lint:css {
   npx stylelint \
     --allow-empty-input \
     --color \
@@ -19,7 +19,7 @@ function css:lint {
     "${@:-${css_globs}}"
 }
 
-function css:format {
+function format:css {
   npx stylelint \
     --fix \
     --allow-empty-input \

--- a/scripts/run/docker_file.sh
+++ b/scripts/run/docker_file.sh
@@ -2,19 +2,19 @@
 
 dockerfile_globs=(Dockerfile*)
 
-function dockerfile:help {
+function help:dockerfile {
   cat <<EOF
 
 Dockerfile commands:
-  dockerfile:format           Format all Dockerfiles
-  dockerfile:lint             Lint all Dockerfiles
+  format:dockerfile           Format all Dockerfiles
+  lint:dockerfile             Lint all Dockerfiles
 EOF
 }
 
-function dockerfile:lint {
+function lint:dockerfile {
   hadolint "${@:-${dockerfile_globs[@]}}"
 }
 
-function dockerfile:format {
+function format:dockerfile {
   shfmt -w "${@:-${dockerfile_globs[@]}}"
 }

--- a/scripts/run/git.sh
+++ b/scripts/run/git.sh
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 
-function git:help {
+function help:git {
   cat <<EOF
 
 Git commands:
-  git:commit:lint                       Lint git commit message
-  git:commit:is-contributor-dependabot  Check if Dependabot is (co-)author of the commit
+  lint:git:commit                       Lint git commit message
+  is-contributor-dependabot:git:commit  Check if Dependabot is (co-)author of the commit
 EOF
 }
 
 # NOTE: Dependabot is not flexible to apply commitlint rules
 # see: https://github.com/dependabot/dependabot-core/issues/1666
 # see: https://github.com/dependabot/dependabot-core/issues/2056
-function git:commit:lint {
+function lint:git:commit {
   local commit_message
 
-  if git:commit:is-contributor-dependabot; then
+  if is-contributor-dependabot:git:commit; then
     warning "SKIPPED './run ${FUNCNAME[0]}': Dependabot is (co-)author of latest commit"
 
     close
@@ -26,7 +26,7 @@ function git:commit:lint {
   echo "${commit_message}" | npx commitlint --color
 }
 
-function git:commit:is-contributor-dependabot {
+function is-contributor-dependabot:git:commit {
   is_author_dependabot || is_co_author_dependabot
 }
 

--- a/scripts/run/html.sh
+++ b/scripts/run/html.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-function html:help {
+function help:html {
   cat <<EOF
 
 HTML commands:
-  html:lint                   Lint HTML files and templates
+  lint:html                   Lint HTML files and templates
 EOF
 }
 
-function html:lint {
+function lint:html {
   local ignore_globs=(
     **/.git/**
     **/.history/**

--- a/scripts/run/javascript.sh
+++ b/scripts/run/javascript.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
-function js:help {
+function help:js {
   cat <<EOF
 
 Javascript commands:
-  js:format                  Format JS files and any files containing Javascript
-  js:lint                    Lint JS files and any files containing Javascript
+  format:js                  Format JS files and any files containing Javascript
+  lint:js                    Lint JS files and any files containing Javascript
 EOF
 }
 
-function js:lint {
+function lint:js {
   npx eslint \
     --cache \
     --color \
@@ -19,7 +19,7 @@ function js:lint {
     "${@:-.}"
 }
 
-function js:format {
+function format:js {
   npx eslint \
     --fix \
     --fix-type layout \

--- a/scripts/run/markdown.sh
+++ b/scripts/run/markdown.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-function markdown:help {
+function help:markdown {
   cat <<EOF
 
 Markdown commands:
-  markdown:lint               Lint markdown files
+  lint:markdown               Lint markdown files
 EOF
 }
 
-function markdown:lint {
+function lint:markdown {
   npx markdownlint "${@:-.}"
 }

--- a/scripts/run/prettier.sh
+++ b/scripts/run/prettier.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
-function prettier:help {
+function help:prettier {
   cat <<EOF
 
 Prettier commands:
-  prettier:format             Format files handled by Prettier
-  prettier:lint               Lint files handled by Prettier
+  format:prettier             Format files handled by Prettier
+  lint:prettier               Lint files handled by Prettier
 EOF
 }
 
-function prettier:lint {
+function lint:prettier {
   npx prettier --check "${@:-.}"
 }
 
-function prettier:format {
+function format:prettier {
   npx prettier --list-different --write "${@:-.}"
 }

--- a/scripts/run/release.sh
+++ b/scripts/run/release.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
-function release:help {
+function help:release {
   cat <<EOF
 
 Release commands:
   release                     Update CHANGELOG.md and version files, cut a release and publish to Github
   release:ci [MODIFIER]       Release from CI. If modifier given, it will prerelease.
   release:dry-run             Simulate cutting a release without updating files or pushing to git
-  release:test                Dry run release, run tests for release
-  release:hooks:test          Run tests for hooks during a release
+  test:release                Dry run release, run tests for release
+  test:release:hooks          Run tests for hooks during a release
   prerelease                  Cut a prerelease, tag with a suffix it and publish it to Github (default: dev)
   - Usage: prerelease [dev|alpha|beta|rc]
-  release-it:custom:test      Run tests related to custom hooks and/or plugins for release-it
+  test:release-it:custom      Run tests related to custom hooks and/or plugins for release-it
 EOF
 }
 
@@ -38,10 +38,10 @@ function release:dry-run {
     --git.pushRepo="git://fake.host.for.dry.run:user/repo"
 }
 
-function release:test {
-  release-it:custom:test
+function test:release {
+  test:release-it:custom
   release:dry-run
-  release:hooks:test
+  test:release:hooks
 }
 
 function prerelease {
@@ -56,13 +56,13 @@ function prerelease {
   release "calendar.${modifier}" --github.preRelease
 }
 
-function release-it:custom:test {
+function test:release-it:custom {
   for path in ./scripts/release-it/tests/**/*.test.js; do
     node "${path}"
   done
 }
 
-function release:hooks:test {
+function test:release:hooks {
   function reset_updated_files {
     local updated_files=(
       CHANGELOG.md

--- a/scripts/run/shell.sh
+++ b/scripts/run/shell.sh
@@ -9,19 +9,19 @@ shell_scripts_globs=(
   scripts/**/*.sh
 )
 
-function shell:help {
+function help:shell {
   cat <<EOF
 
 Shell commands:
-  shell:format                Format given Shell scripts
-  shell:lint                  Lint given Shell scripts
+  format:shell                Format given Shell scripts
+  lint:shell                  Lint given Shell scripts
 EOF
 }
 
-function shell:lint {
+function lint:shell {
   shellcheck -x "${@:-${shell_scripts_globs[@]}}"
 }
 
-function shell:format {
+function format:shell {
   shfmt -w "${@:-${shell_scripts_globs[@]}}"
 }

--- a/scripts/run/spellcheck.sh
+++ b/scripts/run/spellcheck.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-function spellcheck:help {
+function help:spellcheck {
   cat <<EOF
 
 Spellcheck commands:
-  spellcheck:lint             Run spellcheck
+  lint:spellcheck             Run spellcheck
 EOF
 }
 
-function spellcheck:lint {
+function lint:spellcheck {
   npx cspell lint \
     --cache \
     --color \


### PR DESCRIPTION
- Script names are now as follow: [purpose]:[scope]
- Rename `install-deps` to `install:deps`
- Rename `lint-staged` to `lint:staged`
- Adapt documentation