### PR TITLE
chore(vscode): Migrate htmlhint extension to `HTMLHint.vscode-htmlhint`

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,7 @@
     "editorconfig.editorconfig",
 
     // HTML:
-    "mkaufman.htmlhint",
+    "HTMLHint.vscode-htmlhint",
     "bradgashler.htmltagwrap",
     "formulahendry.auto-rename-tag",
 


### PR DESCRIPTION
Related to #603 