### PR TITLE
ci: Replace deprecated `set-output`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
           image_target="ci"
           image_repository="aifrak/template-repo"
 
-          echo "::set-output name=image-target::$image_target"
-          echo "::set-output name=image-tag::$image_repository:$image_target"
-          echo "::set-output name=cache-old::/tmp/.buildx-cache"
-          echo "::set-output name=cache-new::/tmp/.buildx-cache-new"
+          echo "IMAGE_TARGET=$image_target" >> $GITHUB_OUTPUT
+          echo "IMAGE_TAG=$image_repository:$image_target" >> $GITHUB_OUTPUT
+          echo "CACHE_OLD=/tmp/.buildx-cache" >> $GITHUB_OUTPUT
+          echo "CACHE_NEW=/tmp/.buildx-cache-new" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.2.1
@@ -38,7 +38,7 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v3.2.3
         with:
-          path: ${{ steps.docker-params.outputs.cache-old }}
+          path: ${{ steps.docker-params.outputs.CACHE_OLD }}
           key: |
             ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
@@ -48,21 +48,21 @@ jobs:
         uses: docker/build-push-action@v3.2.0
         with:
           load: true
-          target: ${{ steps.docker-params.outputs.image-target }}
-          tags: ${{ steps.docker-params.outputs.image-tag }}
+          target: ${{ steps.docker-params.outputs.IMAGE_TARGET }}
+          tags: ${{ steps.docker-params.outputs.IMAGE_TAG }}
           build-args: |
             USER_UID=${{ env.USER_UID }}
             USER_GID=${{ env.USER_GID }}
-          cache-from: type=local,src=${{ steps.docker-params.outputs.cache-old }}
-          cache-to: type=local,dest=${{ steps.docker-params.outputs.cache-new }}
+          cache-from: type=local,src=${{ steps.docker-params.outputs.CACHE_OLD }}
+          cache-to: type=local,dest=${{ steps.docker-params.outputs.CACHE_NEW }}
 
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252
       # https://github.com/moby/buildkit/issues/1896
       - name: Move Docker cache
         run: |
-          rm -rf ${{ steps.docker-params.outputs.cache-old }}
-          mv ${{ steps.docker-params.outputs.cache-new }} ${{ steps.docker-params.outputs.cache-old }}
+          rm -rf ${{ steps.docker-params.outputs.CACHE_OLD }}
+          mv ${{ steps.docker-params.outputs.CACHE_NEW }} ${{ steps.docker-params.outputs.CACHE_OLD }}
 
       - name: Starts all docker services
         run: |
@@ -75,7 +75,7 @@ jobs:
       - name: Get versions
         id: versions
         run: |
-          echo "::set-output name=node::$(./run --dc-ci dc:exec npm -v)"
+          echo "NODE=$(./run --dc-ci dc:exec npm -v)" >> $GITHUB_OUTPUT
 
       # —————————————————————————————————————————————— #
       #                      Cache                     #
@@ -92,9 +92,9 @@ jobs:
             **/.eslintcache
             **/.stylelintcache
           key: |
-            ${{ runner.os }}-node-${{ steps.versions.outputs.node }}-${{ hashFiles('**/package-lock.json') }}
+            ${{ runner.os }}-node-${{ steps.versions.outputs.NODE }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-${{ steps.versions.outputs.node }}-
+            ${{ runner.os }}-node-${{ steps.versions.outputs.NODE }}-
 
       # —————————————————————————————————————————————— #
       #                  Dependencies                  #
@@ -125,13 +125,13 @@ jobs:
             run_lint_git_commit=true;
           fi
 
-          echo "::set-output name=flag::$run_lint_git_commit"
+          echo "FLAG=$run_lint_git_commit" >> $GITHUB_OUTPUT
 
       - name: Test and lint
         run: |
           included_opts=
 
-          if [[ ${{ steps.lint-git-commit.outputs.flag }} = true ]]; then
+          if [[ ${{ steps.lint-git-commit.outputs.FLAG }} = true ]]; then
             included_opts="--include lint:git:commit"
           fi
 


### PR DESCRIPTION
More information [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).