### PR TITLE
chore(docker): Install locales as recommended in README from ubuntu image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,13 @@ RUN set -e \
     git=1:2.34.1-* \
     locales=2.35-* \
   && echo "--- Add locales ---" \
-  && sed -i "/en_US.UTF-8/s/^# //g" /etc/locale.gen \
-  && locale-gen "en_US.UTF-8" \
+  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
   && echo "--- Clean ---" \
   && apt-get clean \
   && apt-get autoremove \
   && rm -rf /var/lib/apt/lists/*
 
+ENV LANG=en_US.utf8
 ENV USERNAME=app-user
 ARG GROUPNAME=${USERNAME}
 ARG USER_UID=1000

--- a/spellcheck/dictionaries/bash-custom.txt
+++ b/spellcheck/dictionaries/bash-custom.txt
@@ -4,6 +4,7 @@ buildx
 chmod
 FUNCNAME
 gnupg
+localedef
 mkdir
 noninteractive
 NOPASSWD


### PR DESCRIPTION
The README from the ubuntu image states the following:

> Given that it is a minimal install of Ubuntu, this image only includes the C, C.UTF-8, and POSIX locales by default. For most uses requiring a UTF-8 locale, C.UTF-8 is likely sufficient (-e LANG=C.UTF-8 or ENV LANG C.UTF-8).   
For uses where that is not sufficient, other locales can be installed/generated via the locales package. [PostgreSQL has a good example of doing so](https://github.com/docker-library/postgres/blob/69bc540ecfffecce72d49fa7e4a46680350037f9/9.6/Dockerfile#L21-L24), copied below:  
RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
ENV LANG en_US.utf8

Source: https://hub.docker.com/_/ubuntu