### PR TITLE
chore(vscode): Fix prettier load module error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,7 +59,6 @@
   },
 
   // Prettier:
-  "prettier.prettierPath": "./node_modules/prettier",
   "prettier.useEditorConfig": true,
 
   // CSS:


### PR DESCRIPTION
Stack trace:
```log
"ERROR" - 10:16:39 AM] Failed to load module. If you have prettier or plugins referenced in package.json, ensure you have run `npm install`
["ERROR" - 10:16:39 AM] Cannot load Prettier version from package.json
```

Related to #786